### PR TITLE
1. fix the issue: "AttributeError: 'Thread' object has no attribute '…

### DIFF
--- a/openrasp_iast/core/modules/monitor.py
+++ b/openrasp_iast/core/modules/monitor.py
@@ -274,12 +274,12 @@ class Monitor(base.BaseModule):
         #     self.crash_module = "Monitor_web_console"
         #     return False
 
-        if self.cloud_thread is not None and not self.cloud_thread.isAlive():
+        if self.cloud_thread is not None and not self.cloud_thread.is_alive():
             Logger().error("Detect monitor cloud thread stopped, Monitor exit!")
             self.crash_module = "cloud_thread"
             return False
 
-        if self.transaction_thread is not None and not self.transaction_thread.isAlive():
+        if self.transaction_thread is not None and not self.transaction_thread.is_alive():
             Logger().error("Detect monitor cloud transaction thread stopped, Monitor exit!")
             self.crash_module = "transaction_thread"
             return False


### PR DESCRIPTION
```
openrasp-iast_1   | [!] Module down with exception:
openrasp-iast_1   | Traceback (most recent call last):
openrasp-iast_1   |   File "/home/openrasp-iast/openrasp_iast/core/modules/base.py", line 72, in _run_module
openrasp-iast_1   |     module.run()
openrasp-iast_1   |   File "/home/openrasp-iast/openrasp_iast/core/modules/monitor.py", line 415, in run
openrasp-iast_1   |     if self._check_alive():
openrasp-iast_1   |   File "/home/openrasp-iast/openrasp_iast/core/modules/monitor.py", line 277, in _check_alive
openrasp-iast_1   |     if self.cloud_thread is not None and not self.cloud_thread.isAlive():
openrasp-iast_1   | AttributeError: 'Thread' object has no attribute 'isAlive'
```
Threading.Thread 's method isAlive() was renamed to is_alive() since Python 3.9.0