### PR TITLE
The version comparison will get failed while python version > 3.10.

### DIFF
--- a/openrasp_iast/main.py
+++ b/openrasp_iast/main.py
@@ -35,8 +35,9 @@ from core.components.config import Config
 
 
 def init_check():
-    version = float(platform.python_version()[:3])
-    if version < 3.6:
+    from packaging import version
+    currentversion = platform.python_version()
+    if version.parse(currentversion) < version.parse("3.6"):
         print("[!] You must run this tool with Python 3.6 or newer version.")
         sys.exit(1)
 

--- a/openrasp_iast/main.py
+++ b/openrasp_iast/main.py
@@ -35,9 +35,8 @@ from core.components.config import Config
 
 
 def init_check():
-    from packaging import version
-    currentversion = platform.python_version()
-    if version.parse(currentversion) < version.parse("3.6"):
+    version_parts = platform.python_version().split(".")
+    if int(version_parts[0]) < 3 or (int(version_parts[0]) == 3 and int(version_parts[1]) < 6):
         print("[!] You must run this tool with Python 3.6 or newer version.")
         sys.exit(1)
 


### PR DESCRIPTION
A patch for:
1. The version comparison will get failed while python version > 3.10.